### PR TITLE
Ignore standard vim swap files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 /libpeerconnection.log
 npm-debug.log
 testem.log
+*.swp


### PR DESCRIPTION
An update to .gitignore to ignore the standard temporary files that vim creates
